### PR TITLE
Fix PTF numbers required for host debugger

### DIFF
--- a/content/code-ibmi-debug/ptfs.md
+++ b/content/code-ibmi-debug/ptfs.md
@@ -1,8 +1,8 @@
 To make use of the Debug Service, PTFs are required. Users cannot setup new certificates or run the Debug Service without these PTFs.
 
 * Host debugger in 5770SS1:
-   * IBM i 7.5 PTF SI80368 and SI81035
-   * IBM i 7.4 PTF SI80364 and SI81031
-   * IBM i 7.3 PTF SI79707 and SI80858
+   * IBM i 7.5 PTF SI83666 and SI81035
+   * IBM i 7.4 PTF SI83683 and SI81031
+   * IBM i 7.3 PTF SI83692 and SI80858
 
 After you have installed the PTFs, the connection inside of Visual Studio Code will need to be restarted.


### PR DESCRIPTION
The PTF's for host debugger has been superseded - this change will show the new PTF numbers.